### PR TITLE
Refactor/displaying form image

### DIFF
--- a/app/(landing-page)/projects/[id]/page.tsx
+++ b/app/(landing-page)/projects/[id]/page.tsx
@@ -89,7 +89,7 @@ export default async function Page({params: {id}}: PageProps) {
                 {websiteUrl ? (
                   <Button variant="secondary" className="max-w-[14rem] flex-1 gap-3 px-8" asChild>
                     <a href={websiteUrl} target="_blank" rel="noopener noreferrer">
-                      <GlobeIcon className="size-4" />
+                      <GlobeIcon size={16} />
                       Project website
                     </a>
                   </Button>

--- a/components/dashboard/forms/about-form.tsx
+++ b/components/dashboard/forms/about-form.tsx
@@ -3,10 +3,10 @@
 import React from "react";
 import {FormProvider, useForm} from "react-hook-form";
 import {zodResolver} from "@hookform/resolvers/zod";
-import {FileX2Icon} from "lucide-react";
+import {PencilIcon, TrashIcon} from "lucide-react";
 
 import {Button} from "~/components/ui/button";
-import {Dropzone} from "~/components/ui/dropzone";
+import {Dropzone, DropzoneContent} from "~/components/ui/dropzone";
 import {FileThumbnailCard} from "~/components/ui/file-thumbnail";
 import {FormControl, FormField, FormItem, FormLabel, FormMessage} from "~/components/ui/form";
 import {Heading} from "~/components/ui/heading";
@@ -98,15 +98,29 @@ const AboutForm = ({snippets, currentImage}: AboutFormProps) => {
                 <FileThumbnailCard
                   file={value}
                   actions={
-                    <Button variant="secondary" size="sm" onClick={() => onChange(undefined)}>
-                      <FileX2Icon size={16} />
-                      Delete image
-                    </Button>
+                    <>
+                      <Dropzone
+                        name={name}
+                        onDrop={onChange}
+                        accept={acceptedImageTypes}
+                        className="size-10 cursor-pointer p-0">
+                        <PencilIcon size={16} />
+                        <span className="sr-only">Change image</span>
+                      </Dropzone>
+
+                      <Button variant="outline" size="icon" onClick={() => onChange(undefined)}>
+                        <TrashIcon size={16} />
+                        <span className="sr-only">Delete image</span>
+                      </Button>
+                    </>
                   }
                 />
               ) : (
-                <Dropzone name={name} onDrop={onChange} accept={acceptedImageTypes} />
+                <Dropzone name={name} onDrop={onChange} accept={acceptedImageTypes}>
+                  <DropzoneContent />
+                </Dropzone>
               )}
+
               <FormMessage />
             </FormItem>
           )}

--- a/components/dashboard/forms/experience-item-form.tsx
+++ b/components/dashboard/forms/experience-item-form.tsx
@@ -134,7 +134,7 @@ const ExperienceItemForm = ({experienceItem}: ExperienceItemFormProps) => {
                   <PopoverTrigger asChild>
                     <FormControl>
                       <Button variant="outline" className="w-full">
-                        <CalendarIcon className="mr-2 h-4 w-4" />
+                        <CalendarIcon size={16} />
                         <span className="flex-1">{value ? format(value, "LLL dd, y") : "Pick start date"}</span>
                       </Button>
                     </FormControl>
@@ -167,7 +167,7 @@ const ExperienceItemForm = ({experienceItem}: ExperienceItemFormProps) => {
                   <PopoverTrigger asChild>
                     <FormControl>
                       <Button variant="outline" className="w-full">
-                        <CalendarIcon className="mr-2 h-4 w-4" />
+                        <CalendarIcon size={16} />
                         <span className="flex-1">{value ? format(value, "LLL dd, y") : "Pick end date"}</span>
                       </Button>
                     </FormControl>

--- a/components/dashboard/forms/project-item-form.tsx
+++ b/components/dashboard/forms/project-item-form.tsx
@@ -3,11 +3,11 @@
 import React from "react";
 import {FormProvider, useForm} from "react-hook-form";
 import {zodResolver} from "@hookform/resolvers/zod";
-import {FileX2Icon} from "lucide-react";
+import {PencilIcon} from "lucide-react";
 import {useRouter} from "next/navigation";
 
 import {Button} from "~/components/ui/button";
-import {Dropzone} from "~/components/ui/dropzone";
+import {Dropzone, DropzoneContent} from "~/components/ui/dropzone";
 import {FileThumbnailCard} from "~/components/ui/file-thumbnail";
 import {FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage} from "~/components/ui/form";
 import {Input} from "~/components/ui/input";
@@ -89,14 +89,20 @@ const ProjectItemForm = ({project}: ProjectItemFormProps) => {
                 <FileThumbnailCard
                   file={value}
                   actions={
-                    <Button variant="secondary" size="sm" onClick={() => onChange(undefined)}>
-                      <FileX2Icon size={16} />
-                      Delete image
-                    </Button>
+                    <Dropzone
+                      name={name}
+                      onDrop={onChange}
+                      accept={acceptedImageTypes}
+                      className="size-10 cursor-pointer p-0">
+                      <PencilIcon size={16} />
+                      <span className="sr-only">Change image</span>
+                    </Dropzone>
                   }
                 />
               ) : (
-                <Dropzone name={name} onDrop={onChange} accept={acceptedImageTypes} />
+                <Dropzone name={name} onDrop={onChange} accept={acceptedImageTypes}>
+                  <DropzoneContent />
+                </Dropzone>
               )}
               <FormMessage />
             </FormItem>
@@ -142,14 +148,20 @@ const ProjectItemForm = ({project}: ProjectItemFormProps) => {
                 <FileThumbnailCard
                   file={value}
                   actions={
-                    <Button variant="secondary" size="sm" onClick={() => onChange(undefined)}>
-                      <FileX2Icon size={16} />
-                      Delete image
-                    </Button>
+                    <Dropzone
+                      name={name}
+                      onDrop={onChange}
+                      accept={acceptedImageTypes}
+                      className="size-10 cursor-pointer p-0">
+                      <PencilIcon size={16} />
+                      <span className="sr-only">Change image</span>
+                    </Dropzone>
                   }
                 />
               ) : (
-                <Dropzone name={name} onDrop={onChange} accept={acceptedImageTypes} />
+                <Dropzone name={name} onDrop={onChange} accept={acceptedImageTypes}>
+                  <DropzoneContent />
+                </Dropzone>
               )}
               <FormMessage />
             </FormItem>

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -40,8 +40,8 @@ const Calendar = ({classNames, ...props}: React.ComponentProps<typeof DayPicker>
         ...classNames
       }}
       components={{
-        IconLeft: () => <ChevronLeftIcon className="size-4" />,
-        IconRight: () => <ChevronRightIcon className="size-4" />
+        IconLeft: () => <ChevronLeftIcon size={16} />,
+        IconRight: () => <ChevronRightIcon size={16} />
       }}
       {...props}
     />

--- a/components/ui/file-thumbnail.tsx
+++ b/components/ui/file-thumbnail.tsx
@@ -59,7 +59,7 @@ const FileThumbnailCard = React.forwardRef<HTMLDivElement, FileThumbnailCardProp
           <p className="w-full truncate font-poppins text-xs font-semibold">{file.name}</p>
           <p className="mb-auto text-xs leading-6 text-muted-foreground">{convertBytesToMB(file.size)}</p>
 
-          {actions}
+          {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
         </div>
       </div>
     );

--- a/components/ui/file-thumbnail.tsx
+++ b/components/ui/file-thumbnail.tsx
@@ -37,7 +37,7 @@ const FileThumbnail = ({file, size, className}: FileThumbnailProps) => {
         // Priority is set to true by default as the component will always be above the fold
         <Image src={url} fill style={{objectFit: "cover"}} sizes="192px" alt="" priority />
       ) : (
-        <FileIcon className="size-12 stroke-1 text-muted-foreground" />
+        <FileIcon size={40} className="stroke-1 text-muted-foreground" />
       )}
     </div>
   );


### PR DESCRIPTION
The Dropzone component has been updated. It is now possible to instantly change an image without deleting it first. It is also easier to use the dropzone component with different content.

Before:
![Screenshot 2024-07-26 at 17-50-14 Dashboard Projects](https://github.com/user-attachments/assets/8f0203d5-1640-4992-8807-b7778974502b)

After:
![Screenshot 2024-07-26 at 17-49-30 Dashboard Projects](https://github.com/user-attachments/assets/ac69c085-5469-4b1c-bb2f-f3052b55731d)

- FileThumbnail: Wrap card actions in an additional flex wrapper
- Dropzone: Extracted dropzone content into a separate component, added dropzone context
- Updated the about & project image actions
- Replaced icon size class with size property